### PR TITLE
ci: Fix auto-release

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -1,7 +1,7 @@
 name: release-automated
 on:
   push:
-    branches: [ release, alpha, beta, next-major, 'release-[0-9]+.x.x' ]
+    branches: [ main, master, release, alpha, beta, next-major, 'release-[0-9]+.x.x' ]
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/release.config.js
+++ b/release.config.js
@@ -2,8 +2,14 @@
  * Semantic Release Config
  */
 
-const fs = require('fs').promises;
-const path = require('path');
+// For CommonJS use:
+// const { readFile } = require('fs').promises;
+// const { resolve } = require('path');
+
+// For ES6 modules use:
+import { readFile } from 'fs/promises';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 // Get env vars
 const ref = process.env.GITHUB_REF;
@@ -24,11 +30,12 @@ const templates = {
 async function config() {
 
   // Get branch
-  const branch = ref.split('/').pop();
+  const branch = ref?.split('/')?.pop()?.split('-')[0] || '(current branch could not be determined)';
   console.log(`Running on branch: ${branch}`);
 
   // Set changelog file
-  const changelogFile = `./changelogs/CHANGELOG_${branch}.md`;
+  //const changelogFile = `./changelogs/CHANGELOG_${branch}.md`;
+  const changelogFile = `./CHANGELOG.md`;
   console.log(`Changelog file output to: ${changelogFile}`);
 
   // Load template file contents
@@ -36,17 +43,17 @@ async function config() {
 
   const config = {
     branches: [
+      'main',
+      'master',
       'release',
-      // { name: 'alpha', prerelease: true },
-      // { name: 'beta', prerelease: true },
-      // 'next-major',
+      { name: 'alpha', prerelease: true },
+      { name: 'beta', prerelease: true },
+      'next-major',
       // Long-Term-Support branches
-      // { name: '1.x.x', range: '1.x.x', channel: '1.x.x' },
-      // { name: '2.x.x', range: '2.x.x', channel: '2.x.x' },
-      // { name: '3.x.x', range: '3.x.x', channel: '3.x.x' },
-      // { name: '4.x.x', range: '4.x.x', channel: '4.x.x' },
-      // { name: '5.x.x', range: '5.x.x', channel: '5.x.x' },
-      // { name: '6.x.x', range: '6.x.x', channel: '6.x.x' },
+      // { name: 'release-1', range: '1.x.x', channel: '1.x' },
+      // { name: 'release-2', range: '2.x.x', channel: '2.x' },
+      // { name: 'release-3', range: '3.x.x', channel: '3.x' },
+      // { name: 'release-4', range: '4.x.x', channel: '4.x' },
     ],
     dryRun: false,
     debug: true,
@@ -60,13 +67,13 @@ async function config() {
           { scope: 'no-release', release: false },
         ],
         parserOpts: {
-          noteKeywords: [ 'BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING' ],
+          noteKeywords: [ 'BREAKING CHANGE' ],
         },
       }],
       ['@semantic-release/release-notes-generator', {
         preset: 'angular',
         parserOpts: {
-          noteKeywords: ['BREAKING CHANGE']
+          noteKeywords: [ 'BREAKING CHANGE' ]
         },
         writerOpts: {
           commitsSort: ['subject', 'scope'],
@@ -83,23 +90,13 @@ async function config() {
         'npmPublish': true,
       }],
       ['@semantic-release/git', {
-        assets: [changelogFile, 'package.json', 'package-lock.json', 'npm-shrinkwrap.json'],
+        assets: [changelogFile, 'package.json', 'package-lock.json'],
       }],
-      ["@semantic-release/github", {
+      ['@semantic-release/github', {
         successComment: getReleaseComment(),
         labels: ['type:ci'],
         releasedLabels: ['state:released<%= nextRelease.channel ? `-\${nextRelease.channel}` : "" %>']
       }],
-      // Back-merge module runs last because if it fails it should not impede the release process
-      // [
-      //   "@saithodev/semantic-release-backmerge",
-      //   {
-      //     "branches": [
-      //       { from: "beta", to: "alpha" },
-      //       { from: "release", to: "beta" },
-      //     ]
-      //   }
-      // ],
     ],
   };
 
@@ -108,19 +105,24 @@ async function config() {
 
 async function loadTemplates() {
   for (const template of Object.keys(templates)) {
-    const text = await readFile(path.resolve(__dirname, resourcePath, templates[template].file));
+    // For ES6 modules use:
+    const fileUrl = import.meta.url;
+    const __dirname = dirname(fileURLToPath(fileUrl));
+
+    const filePath = resolve(__dirname, resourcePath, templates[template].file);
+    const text = await readFile(filePath, 'utf-8');
     templates[template].text = text;
   }
 }
 
-async function readFile(filePath) {
-  return await fs.readFile(filePath, 'utf-8');
-}
-
 function getReleaseComment() {
   const url = repositoryUrl + '/releases/tag/${nextRelease.gitTag}';
-  const comment = '🎉 This pull request has been released in version [${nextRelease.version}](' + url + ')';
+  const comment = '🎉 This change has been released in version [${nextRelease.version}](' + url + ')';
   return comment;
 }
 
-module.exports = config();
+// For CommonJS use:
+// module.exports = config();
+
+// For ES6 modules use:
+export default config();


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/mtrezza/parse-server-api-mail-adapter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/mtrezza/parse-server-api-mail-adapter/issues?q=is%3Aissue).

### Issue Description

- Branch naming `release` creates issues with parse-github-assitant, since it applies rules that are intended for repos with pre-release branches (alpha, beta), not for single branch repos in which the working branch is also the only release branch as is the case here.

### Approach

- Renamed working branch from `release` to `main` since we only maintain 1 branch which is the working and release branch.
- Adapted semantic release config

