### PR TITLE
refactor: Bump @semantic-release/github from 12.0.5 to 12.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/commit-analyzer": "13.0.1",
         "@semantic-release/git": "10.0.1",
-        "@semantic-release/github": "12.0.5",
+        "@semantic-release/github": "12.0.6",
         "@semantic-release/npm": "13.1.4",
         "@semantic-release/release-notes-generator": "14.1.0",
         "@types/jasmine": "6.0.0",
@@ -2246,9 +2246,9 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.5.tgz",
-      "integrity": "sha512-QEf76UJGbNdq58EWQHBO56YWVQbPDuFOSITkfaI6Q4acpThWqL/jpbrDTilcqo3plRE3NnJko97XLmpCEp4WGw==",
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.6.tgz",
+      "integrity": "sha512-aYYFkwHW3c6YtHwQF0t0+lAjlU+87NFOZuH2CvWFD0Ylivc7MwhZMiHOJ0FMpIgPpCVib/VUAcOwvrW0KnxQtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "13.0.1",
     "@semantic-release/git": "10.0.1",
-    "@semantic-release/github": "12.0.5",
+    "@semantic-release/github": "12.0.6",
     "@semantic-release/npm": "13.1.4",
     "@semantic-release/release-notes-generator": "14.1.0",
     "@types/jasmine": "6.0.0",


### PR DESCRIPTION
Closes #179

### Changes

- **12.0.6**: Patch release of @semantic-release/github

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.