### PR TITLE
refactor: Bump jasmine from 6.0.0 to 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint": "7.32.0",
         "eslint-plugin-flowtype": "7.0.0",
         "form-data": "4.0.5",
-        "jasmine": "6.0.0",
+        "jasmine": "6.1.0",
         "jasmine-spec-reporter": "7.0.0",
         "madge": "5.0.1",
         "mailgun.js": "12.7.0",
@@ -5851,24 +5851,24 @@
       }
     },
     "node_modules/jasmine": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.0.0.tgz",
-      "integrity": "sha512-eSPL6LPWT39WwvHSEEbRXuSvioXMTheNhIPaeUT1OPmSprDZwj4S29884DkTx6/tyiOWTWB1N+LdW2ZSg74aEA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.1.0.tgz",
+      "integrity": "sha512-WPphPqEMY0uBRMjuhRHoVoxQNvJuxIMqz0yIcJ3k3oYxBedeGoH60/NXNgasxnx2FvfXrq5/r+2wssJ7WE8ABw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.0.0"
+        "jasmine-core": "~6.1.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.0.1.tgz",
-      "integrity": "sha512-gUtzV5ASR0MLBwDNqri4kBsgKNCcRQd9qOlNw/w/deavD0cl3JmWXXfH8JhKM4LTg6LPTt2IOQ4px3YYfgh2Xg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.1.0.tgz",
+      "integrity": "sha512-p/tjBw58O6vxKIWMlrU+yys8lqR3+l3UrqwNTT7wpj+dQ7N4etQekFM8joI+cWzPDYqZf54kN+hLC1+s5TvZvg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint": "7.32.0",
     "eslint-plugin-flowtype": "7.0.0",
     "form-data": "4.0.5",
-    "jasmine": "6.0.0",
+    "jasmine": "6.1.0",
     "jasmine-spec-reporter": "7.0.0",
     "madge": "5.0.1",
     "mailgun.js": "12.7.0",


### PR DESCRIPTION
Closes #181

### Changes

- **6.1.0**: Minor release of the Jasmine test framework

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.