### PR TITLE
refactor: Bump @types/node from 25.2.3 to 25.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@semantic-release/npm": "13.1.4",
         "@semantic-release/release-notes-generator": "14.1.0",
         "@types/jasmine": "6.0.0",
-        "@types/node": "25.2.3",
+        "@types/node": "25.3.1",
         "babel-eslint": "10.1.0",
         "eslint": "7.32.0",
         "eslint-plugin-flowtype": "7.0.0",
@@ -2702,13 +2702,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
-      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "version": "25.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.1.tgz",
+      "integrity": "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -10924,7 +10924,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@semantic-release/npm": "13.1.4",
     "@semantic-release/release-notes-generator": "14.1.0",
     "@types/jasmine": "6.0.0",
-    "@types/node": "25.2.3",
+    "@types/node": "25.3.1",
     "babel-eslint": "10.1.0",
     "eslint": "7.32.0",
     "eslint-plugin-flowtype": "7.0.0",


### PR DESCRIPTION
Closes #183

### Changes

- **25.3.1**: Minor/patch release of @types/node type definitions

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.