### PR TITLE
refactor: Bump globals from 16.2.0 to 17.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "25.3.1",
         "eslint": "9.39.3",
         "form-data": "4.0.5",
-        "globals": "16.2.0",
+        "globals": "17.4.0",
         "jasmine": "6.1.0",
         "jasmine-spec-reporter": "7.0.0",
         "madge": "5.0.1",
@@ -5283,9 +5283,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
-      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/node": "25.3.1",
     "eslint": "9.39.3",
     "form-data": "4.0.5",
-    "globals": "16.2.0",
+    "globals": "17.4.0",
     "jasmine": "6.1.0",
     "jasmine-spec-reporter": "7.0.0",
     "madge": "5.0.1",


### PR DESCRIPTION
Bump `globals` from 16.2.0 to 17.4.0.

Closes #203