### PR TITLE
refactor: Bump @types/node from 25.5.0 to 25.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@semantic-release/npm": "13.1.5",
         "@semantic-release/release-notes-generator": "14.1.0",
         "@types/jasmine": "6.0.0",
-        "@types/node": "25.5.0",
+        "@types/node": "25.5.2",
         "eslint": "10.1.0",
         "form-data": "4.0.5",
         "globals": "17.4.0",
@@ -2840,9 +2840,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@semantic-release/npm": "13.1.5",
     "@semantic-release/release-notes-generator": "14.1.0",
     "@types/jasmine": "6.0.0",
-    "@types/node": "25.5.0",
+    "@types/node": "25.5.2",
     "eslint": "10.1.0",
     "form-data": "4.0.5",
     "globals": "17.4.0",


### PR DESCRIPTION
Closes #218

## Changes
- Bumps `@types/node` from 25.5.0 to 25.5.2

## Breaking Changes
- None

## Code Changes Required
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript type definitions to the latest stable version for enhanced type checking and improved development environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->