### PR TITLE
refactor: Bump mailgun.js from 12.7.1 to 12.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jasmine": "6.1.0",
         "jasmine-spec-reporter": "7.0.0",
         "madge": "5.0.1",
-        "mailgun.js": "12.7.1",
+        "mailgun.js": "12.8.0",
         "nyc": "18.0.0",
         "semantic-release": "25.0.3",
         "typescript": "6.0.2"
@@ -3149,9 +3149,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5158,9 +5158,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -6745,13 +6745,13 @@
       }
     },
     "node_modules/mailgun.js": {
-      "version": "12.7.1",
-      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-12.7.1.tgz",
-      "integrity": "sha512-VG2zRx4hKVoLGdMDpF5Bt+lkhS6g+eWb547FR4/iozoGEszcT+uf8/0EsPBwnpfI2gYlui3aaPnQCzcFDYvGXQ==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-12.8.0.tgz",
+      "integrity": "sha512-F58kAyPKBPO/HhkUm6q9+3pFDsEVUrhXY7WGLFfjYg6sXrQwvaGBfRIURE/9XUk1/D43rCudaf4VwkNcNDqGLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.12.1",
+        "axios": "^1.15.0",
         "base-64": "^1.0.0",
         "url-join": "^4.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jasmine": "6.1.0",
     "jasmine-spec-reporter": "7.0.0",
     "madge": "5.0.1",
-    "mailgun.js": "12.7.1",
+    "mailgun.js": "12.8.0",
     "nyc": "18.0.0",
     "semantic-release": "25.0.3",
     "typescript": "6.0.2"


### PR DESCRIPTION
Closes #225

### Changes

- **12.8.0**: Added `destroyAll` method to `SuppressionClient` (additive feature).
- Transitive dependency bumps within mailgun.js (axios, lodash, handlebars, basic-ftp, etc.).

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mailgun.js library and related dependencies to their latest versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->