### PR TITLE
refactor: Bump mailgun.js from 12.8.0 to 13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jasmine": "6.2.0",
         "jasmine-spec-reporter": "7.0.0",
         "madge": "5.0.1",
-        "mailgun.js": "12.8.0",
+        "mailgun.js": "13.0.0",
         "nyc": "18.0.0",
         "semantic-release": "25.0.3",
         "typescript": "6.0.3"
@@ -6791,9 +6791,9 @@
       }
     },
     "node_modules/mailgun.js": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-12.8.0.tgz",
-      "integrity": "sha512-F58kAyPKBPO/HhkUm6q9+3pFDsEVUrhXY7WGLFfjYg6sXrQwvaGBfRIURE/9XUk1/D43rCudaf4VwkNcNDqGLg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-13.0.0.tgz",
+      "integrity": "sha512-q59DjkjjN6Q8S6BBiY3aAXv5kdbgwp3JBffa/IFRo2FaaVodrDzRUrvuGyafKYMQXhIPnoVQ2i0f/hOlj4GEBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jasmine": "6.2.0",
     "jasmine-spec-reporter": "7.0.0",
     "madge": "5.0.1",
-    "mailgun.js": "12.8.0",
+    "mailgun.js": "13.0.0",
     "nyc": "18.0.0",
     "semantic-release": "25.0.3",
     "typescript": "6.0.3"


### PR DESCRIPTION
Closes #232

Mirror of the Dependabot PR, bumping `mailgun.js` from `12.8.0` to `13.0.0` (pinned, exact).

Note: in this adapter `mailgun.js` is a `devDependency` — it is used only by `demo/index.js` (and referenced by a payload-conversion spec), not by the adapter's runtime. The only production dependency is `mustache`. This change therefore does not affect the published package's runtime and does not trigger a release (`refactor:`).

### Changes

- **12.9.0**: Added `matchAddress` method to `RoutesClient`; updated vulnerable transitive packages (mailgun/mailgun.js#503, mailgun/mailgun.js#504).
- **13.0.0**: Added `listByAddress` to `MailingListsClient`, `listMembersByAddress` to `MailListsMembers`, and CSV bulk upload for mailing-list members (mailgun/mailgun.js#505). Breaking: removed the optional `address` property from the query parameter of the `MailingLists.list` method.

### Breaking Changes

The only breaking change in v13.0.0 is the removal of the optional `address` query parameter from `MailingLists.list`. This adapter does not use the `MailingLists` client. Its entire use of `mailgun.js` is in `demo/index.js`:

- `new Mailgun(formData)` (constructor)
- `mailgun.client({ username: "api", key })` (client construction)
- `mailgunClient.messages.create(domain, payload)` (sending a message)

None of these APIs changed in v13, so the adapter is unaffected.

### Code Changes Required

None — the upgrade is a drop-in replacement. Only `package.json` and `package-lock.json` change. Locally, `npm run build`, `npm test` (48 specs, 0 failures), and `npm run lint` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Mailgun integration package to version 13.0.0.
  * Refreshed the project’s locked dependency versions for consistent installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->