### PR TITLE
refactor: Bump jasmine from 6.2.0 to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint": "10.7.0",
         "form-data": "4.0.6",
         "globals": "17.6.0",
-        "jasmine": "6.2.0",
+        "jasmine": "6.3.0",
         "jasmine-spec-reporter": "7.0.0",
         "madge": "5.0.1",
         "mailgun.js": "13.3.0",
@@ -6380,24 +6380,24 @@
       }
     },
     "node_modules/jasmine": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.2.0.tgz",
-      "integrity": "sha512-dvYt7bidcu0JvvSbiUnSDW7UQQiflUwDr6C+5wzoZ0J7RY9u+UcoSIzyhMPj6fnU/tC7KinJ5QrjwD2Y9p4T4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.3.0.tgz",
+      "integrity": "sha512-u6L7yYtrtS1JALlp7f4k7Wz7o7ZKXauSKKkXc0L3qUkKrdaxYvNiMHhHp5gtTuVZZXVihXRxS7bWwDBX1wJ7EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.2.0"
+        "jasmine-core": "~6.3.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.2.0.tgz",
-      "integrity": "sha512-b16WZG/pFEFj8qRW1ss7nDuNGYz9ji8BDGj7fJNrROauk5rj/diO3KPOuyIpcgUChdC+c0PfQ8iUk4nHE+EN4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.3.0.tgz",
+      "integrity": "sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint": "10.7.0",
     "form-data": "4.0.6",
     "globals": "17.6.0",
-    "jasmine": "6.2.0",
+    "jasmine": "6.3.0",
     "jasmine-spec-reporter": "7.0.0",
     "madge": "5.0.1",
     "mailgun.js": "13.3.0",


### PR DESCRIPTION
Closes #257

Bumps [jasmine](https://github.com/jasmine/jasmine-npm) devDependency from 6.2.0 to 6.3.0.

## Changes

Routine minor update of the `jasmine` test runner (direct devDependency). Also bumps the transitive `jasmine-core` from 6.2.0 to 6.3.0.

## Breaking Changes

None. This is a minor release with no breaking changes affecting this project.

## Code Changes Required

None. Only `package.json` and `package-lock.json` were updated; no source or spec changes were needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Jasmine development tooling to version 6.3.0.
  * Refreshed the associated locked package versions for consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->