### PR TITLE
refactor: Bump semantic-release from 25.0.3 to 25.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "madge": "5.0.1",
         "mailgun.js": "13.3.0",
         "nyc": "18.0.0",
-        "semantic-release": "25.0.3",
+        "semantic-release": "25.0.8",
         "typescript": "6.0.3"
       },
       "engines": {
@@ -10587,9 +10587,9 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
-      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
+      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "madge": "5.0.1",
     "mailgun.js": "13.3.0",
     "nyc": "18.0.0",
-    "semantic-release": "25.0.3",
+    "semantic-release": "25.0.8",
     "typescript": "6.0.3"
   },
   "engines": {


### PR DESCRIPTION
Closes #270

## Summary
Bumps the direct devDependency `semantic-release` from `25.0.3` to `25.0.8`.

## Details
- Routine patch-range bump of a build/release tooling devDependency.
- `package.json` and `package-lock.json` updated; lockfile churn is confined to the `semantic-release` entry (`lockfileVersion` preserved at `3`).
- Replaces the Dependabot PR #270 so the commit is authored under the maintainer identity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated release tooling dependency to version **25.0.8** to improve release management reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->